### PR TITLE
Customize tag color cu-8686n993r

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -184,6 +184,7 @@ en:
     select_form: Select form
     select_form_tags: Select dashform tags
     select_options: Select options
+    color_options: Color options
     select_placeholder: Select...
     select_query: Select query
     select_query_tags: Select query tags

--- a/lib/motor/version.rb
+++ b/lib/motor/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Motor
-  VERSION = '0.4.24'
+  VERSION = '0.4.25'
 end

--- a/ui/src/data_cells/components/tag.vue
+++ b/ui/src/data_cells/components/tag.vue
@@ -55,7 +55,27 @@ const COLORS = {
   enabled: 'ivu-tag-green',
   resolved: 'ivu-tag-green',
   disabled: 'ivu-tag-red',
-  invalid: 'ivu-tag-red'
+  blue: 'ivu-tag-blue',
+  geek_blue: 'ivu-tag-geekblue',
+  green: 'ivu-tag-green',
+  lime: 'ivu-tag-lime',
+  red: 'ivu-tag-red',
+  yellow: 'ivu-tag-yellow',
+  orange: 'ivu-tag-orange',
+  volcano: 'ivu-tag-volcano',
+  purple: 'ivu-tag-purple',
+  magenta: 'ivu-tag-magenta',
+  pink: 'ivu-tag-pink',
+  cyan: 'ivu-tag-cyan',
+  gray: 'ivu-tag-gray',
+  light_gray: 'ivu-tag-default',
+  default: 'ivu-tag-default',
+  gold: 'ivu-tag-gold',
+  primary: 'ivu-tag-primary',
+  info: 'ivu-tag-blue',
+  success: 'ivu-tag-success',
+  error: 'ivu-tag-error',
+  warning: 'ivu-tag-warning'
 }
 
 export default {

--- a/ui/src/data_cells/components/tag.vue
+++ b/ui/src/data_cells/components/tag.vue
@@ -80,7 +80,11 @@ export default {
   emits: ['tag-click'],
   computed: {
     colorClass () {
-      return COLORS[this.value]
+      if (this.format.color_options) {
+        return COLORS[this.format.color_options[this.value]]
+      } else {
+        return COLORS[this.value]
+      }
     },
     options () {
       return this.format.select_options || {}

--- a/ui/src/data_cells/components/tag.vue
+++ b/ui/src/data_cells/components/tag.vue
@@ -55,6 +55,7 @@ const COLORS = {
   enabled: 'ivu-tag-green',
   resolved: 'ivu-tag-green',
   disabled: 'ivu-tag-red',
+  invalid: 'ivu-tag-red',
   blue: 'ivu-tag-blue',
   geek_blue: 'ivu-tag-geekblue',
   green: 'ivu-tag-green',

--- a/ui/src/settings/components/resource_column_form.vue
+++ b/ui/src/settings/components/resource_column_form.vue
@@ -135,6 +135,16 @@
         />
       </FormItem>
       <FormItem
+        v-if="dataColumn.column_type === 'tag'"
+        :label="i18n['color_options']"
+        prop="format.color_options"
+      >
+        <OptionsInput
+          v-model="dataColumn.format.color_options"
+          :options-text="colorOptionsText"
+        />
+      </FormItem>
+      <FormItem
         :label="i18n['description']"
         prop="description"
       >


### PR DESCRIPTION
Added the ability to customize tag colors. This is done by adding a color_options setting to the format options on a tag's config. On the UI simply edit the color options input when editing the setting for a tag with the format NAME,COLOR ( "," is Motors default delimiter. See below screenshot: 
![Screenshot 2023-12-07 at 10 30 13 AM](https://github.com/Rotessa/motor-admin-rails/assets/59741419/0398bde2-cf66-42ef-afcc-5736bc708ac0)
![image](https://github.com/Rotessa/motor-admin-rails/assets/59741419/cd875dd5-d47c-4f89-9aa1-3d6aab5c75da)
