### PR TITLE
Populate tags from query cu-8686ny4ry

### DIFF
--- a/ui/src/data_forms/components/input.vue
+++ b/ui/src/data_forms/components/input.vue
@@ -60,6 +60,7 @@
     :model-value="dataValue"
     :options="Array.isArray(tagOptions) ? tagOptions : Object.keys(tagOptions)"
     v-bind="$attrs"
+    filterable
     :allow-create="!Object.entries(tagOptions).length"
     :multiple="column.is_array || !!column.format?.split_tags_by"
     :label-function="Object.entries(tagOptions).length ? (option) => tagOptions[option.value.toString()] || titleize(option.value.toString()) : (option) => option.value.toString()"

--- a/ui/src/data_forms/components/input.vue
+++ b/ui/src/data_forms/components/input.vue
@@ -45,6 +45,16 @@
     @update:model-value="$emit('update:modelValue', $event)"
     @select="onSelect"
   />
+  <QueryValueSelect
+    v-else-if="isTagSelect && selectQueryId"
+    :model-value="dataValue"
+    :query-id="selectQueryId"
+    :form-data="formData"
+    :multiple="column.is_array || !!column.format?.split_tags_by"
+    v-bind="$attrs"
+    @update:model-value="$emit('update:modelValue', column.format?.split_tags_by ? $event.join(column.format.split_tags_by) : $event)"
+    @select="onSelect"
+  />
   <MSelect
     v-else-if="isTagSelect"
     :model-value="dataValue"

--- a/ui/src/settings/components/resource_column_form.vue
+++ b/ui/src/settings/components/resource_column_form.vue
@@ -91,6 +91,16 @@
         :reference="dataColumn.reference"
       />
       <FormItem
+        v-if="dataColumn.column_type === 'select' || dataColumn.column_type === 'tag'"
+        :label="i18n['select_query']"
+        prop="format.select_query_id"
+      >
+        <QuerySelect v-model="dataColumn.format.select_query_id" />
+      </FormItem>
+      <p v-if="dataColumn.column_type === 'tag'" class="text-center">
+        - or -
+      </p>
+      <FormItem
         v-if="dataColumn.column_type === 'tag'"
         :label="i18n['select_options']"
         prop="format.select_options"
@@ -107,13 +117,6 @@
             {{ i18n.load_existing_options_from_database }}
           </VButton>
         </div>
-      </FormItem>
-      <FormItem
-        v-if="dataColumn.column_type === 'select'"
-        :label="i18n['select_query']"
-        prop="format.select_query_id"
-      >
-        <QuerySelect v-model="dataColumn.format.select_query_id" />
       </FormItem>
       <FormItem
         v-if="dataColumn.column_type === 'link'"


### PR DESCRIPTION
Add option to populate tags from a query, similar to selects. This doesn't remove the option of hard coding the options, and the custom colors work for either method. 
Bonus: Also made tags searchable in the filters section, just like selects
![image](https://github.com/Rotessa/motor-admin-rails/assets/59741419/70c6d970-1424-4358-81fd-e8dc04fc1566)
