### PR TITLE
Motor enable confirm from UI cu-8686reeak

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    motor-admin (0.4.23)
+    motor-admin (0.4.27)
       ar_lazy_preload (~> 1.0)
       audited (~> 5.0)
       cancancan (~> 3.0)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -305,6 +305,7 @@ en:
     total: Total
     radar_chart: Radar chart
     show_on_table: Show on table
+    with_confirm: With confirm
     map: Map
     audits: Audits
     nothing_to_show_here_yet: Nothing to show here yet 🤷

--- a/lib/motor/version.rb
+++ b/lib/motor/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Motor
-  VERSION = '0.4.25'
+  VERSION = '0.4.27'
 end

--- a/ui/src/settings/components/resource_action_form.vue
+++ b/ui/src/settings/components/resource_action_form.vue
@@ -73,6 +73,13 @@
         >
           {{ ' ' }} {{ i18n['show_on_table'] }}
         </Checkbox>
+        <Checkbox
+          v-if="dataAction.action_type === 'form'"
+          v-model="dataAction.preferences.with_confirm"
+          class="d-block mb-4"
+        >
+          {{ ' ' }} {{ i18n['with_confirm'] }}
+        </Checkbox>
       </div>
     </VForm>
     <div class="d-flex justify-content-between">


### PR DESCRIPTION
Note, it will only display on actions that trigger a form, as method actions don't respect the with_confirm setting. We could probably fix that, but we rarely use the method type, so I didn't bother.
![image](https://github.com/motor-admin/motor-admin-rails/assets/59741419/0d8e7c01-4de5-44b8-8b0b-9022e4eae11d)
